### PR TITLE
Don't display the animated hover underline for smaller breakpoints

### DIFF
--- a/wp-content/themes/pawar2018/sass/site/_header.scss
+++ b/wp-content/themes/pawar2018/sass/site/_header.scss
@@ -109,17 +109,25 @@
     margin: 0;
     padding: 0;
   }
+
   &:hover {
     color: white;
     text-decoration: none;
-	&:after {
-  	  content: '';
-  	  height: 2px;
-  	  display: block;
-  	  background: #fff;
-  	  width: 100%;
+
+    // Don't include the underline created by the :after element
+    // for any smaller breakpoints due to a Safari issue
+    // see: https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+    @include breakpoint(medium) {
+      &:after {
+        content: '';
+        height: 2px;
+        display: block;
+        background: #fff;
+        width: 100%;
+      }
     }
   }
+
   &:after {
 	  content: '';
 	  height: 2px;


### PR DESCRIPTION
The animated underline that shows up when hovering over header navigation items is causing an issue in Safari. The issue is actually a Safari "feature" as described [here](https://css-tricks.com/annoying-mobile-double-tap-link-issue/). The easiest fix is to just not show the underline for smaller breakpoints.