### PR TITLE
fixing these section-headers

### DIFF
--- a/wp-content/themes/pawar2018/sass/components/_headings.scss
+++ b/wp-content/themes/pawar2018/sass/components/_headings.scss
@@ -3,6 +3,7 @@
   text-transform: uppercase;
   font-weight: 900;
   margin: 0 0 1rem 0;
+  font-size: 2.25rem;
   &:after {
     content: "";
     display: block;


### PR DESCRIPTION
# What does this pull request do?
- Explicitly set the section-title font size

# How should the reviewer test this pull request?
-  Make sure the blue H1s have a font size of 36px/2.25rem.

# Include the Basecamp todo for this PR, if there is one.
https://3.basecamp.com/3666950/buckets/2763013/todos/410962954

# Include any screenshots that will help explain this PR.
![screenshot 2017-03-04 14 23 23](https://cloud.githubusercontent.com/assets/282638/23582012/4e254dc4-00e6-11e7-9bf4-f7aecabbec4f.png)
![screenshot 2017-03-04 14 23 12](https://cloud.githubusercontent.com/assets/282638/23582011/4e255c4c-00e6-11e7-9e3f-45529ed37dae.png)

# Any another context you want to provide?
🎃 