### PR TITLE
Update get involved & newsletter templates to use CMS data.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.php]
+indent_size = 2
+
+[*.scss]
+indent_size = 2
+
+[*.js]
+indent_size = 2

--- a/wp-content/themes/pawar2018/page-get-involved.php
+++ b/wp-content/themes/pawar2018/page-get-involved.php
@@ -1,20 +1,21 @@
 <?php get_header(); ?>
+
 <main>
-<section class="hero inner-page" style="background-image: url('<?php echo get_bloginfo('template_url') ?>/assets/get-involved-hero.jpg'); background-size: cover;">
+  <section class="hero inner-page" style="background-image: url('<?php the_field('hero_image'); ?>');">
     <div class="row align-center align-middle">
-        <h1 class="page-title">Get Involved</h1>
-   </div>
-</section>
-<section class="wrapper">
-<div class="main body">
-    <div class="row align-center">
-    <div class="small-12 medium-12 columns">
-        <h1 class="section-title">We're working to win back Illinois. Join Us.</h1>
-        <br>
-        <br>
-        <br>
-        <script type='text/javascript' src='//d1aqhv4sn5kxtx.cloudfront.net/actiontag/at.js'></script>
-        <div class='ngp-form'
+      <h1 class="page-title"><?php the_title(); ?></h1>
+    </div>
+  </section>
+  <section class="wrapper">
+    <div class="main body">
+      <div class="row align-center">
+        <div class="small-12 medium-12 columns">
+          <h1 class="section-title"><?php echo the_field('inner_section_title'); ?></h1>
+          <br>
+          <br>
+          <br>
+          <script type='text/javascript' src='//d1aqhv4sn5kxtx.cloudfront.net/actiontag/at.js'></script>
+          <div class='ngp-form'
             data-template='oberon'
             data-id='3208625543266699776'
             data-endpoint='https://api.myngp.com/'
@@ -25,22 +26,23 @@
             data-inline-errors='true'
             data-fastaction-nologin='true'
             data-embed='true'>
+          </div>
         </div>
-    </div>
-    </div>
+      </div>
     </div>
     <div class="sidebar">
-        <div class="row align-center">
-            <div class="small-12 medium-8 columns ">
-                <p>
-                    <strong>AMEYA PAWAR FOR GOVERNOR</strong>
-                    <a href="mailto:info@pawar2018.com">info@pawar2018.com</a><br />
-                    P.O. Box 577162<br />
-                    Chicago, IL 60657<br />
-                </p>
-            </div>
+      <div class="row align-center">
+        <div class="small-12 medium-8 columns ">
+          <p>
+            <strong>AMEYA PAWAR FOR GOVERNOR</strong>
+            <a href="mailto:info@pawar2018.com">info@pawar2018.com</a><br />
+            P.O. Box 577162<br />
+            Chicago, IL 60657<br />
+          </p>
         </div>
+      </div>
     </div>
-</section>
+  </section>
 </main>
+
 <?php get_footer(); ?>

--- a/wp-content/themes/pawar2018/page-newsletter.php
+++ b/wp-content/themes/pawar2018/page-newsletter.php
@@ -1,30 +1,31 @@
 <?php get_header(); ?>
+
 <main>
- <section class="hero">
- </section>
- <section class="body">
+  <section class="hero inner-page" style="background-image: url('<?php the_field('hero_image'); ?>');"></section>
+  <section class="body">
     <div class="row">
-        <div class="small-12 medium-8 columns">
-            <h1 class="section-title">Sign up to receive updates</h1>
-        </div>
+      <div class="small-12 medium-8 columns">
+        <h1 class="section-title"><?php echo the_field('inner_section_title'); ?></h1>
+      </div>
     </div>
     <div class="row align-center">
-        <div class="column">
-            <script type='text/javascript' src='//d1aqhv4sn5kxtx.cloudfront.net/actiontag/at.js'></script>
-            <div class='ngp-form'
-            data-template='oberon'
-            data-id='8251531226014812672'
-            data-endpoint='https://api.myngp.com/'
-            data-formdef-endpoint='//formdefs.s3.amazonaws.com/api.myngp.com'
-            data-fastaction-endpoint='https://fastaction.ngpvan.com/'
-            data-databag='everybody'
-            data-resource-path='https://d1aqhv4sn5kxtx.cloudfront.net/'
-            data-inline-errors='true'
-            data-fastaction-nologin='true'
-            data-embed='true'>
+      <div class="column">
+        <script type='text/javascript' src='//d1aqhv4sn5kxtx.cloudfront.net/actiontag/at.js'></script>
+        <div class='ngp-form'
+          data-template='oberon'
+          data-id='8251531226014812672'
+          data-endpoint='https://api.myngp.com/'
+          data-formdef-endpoint='//formdefs.s3.amazonaws.com/api.myngp.com'
+          data-fastaction-endpoint='https://fastaction.ngpvan.com/'
+          data-databag='everybody'
+          data-resource-path='https://d1aqhv4sn5kxtx.cloudfront.net/'
+          data-inline-errors='true'
+          data-fastaction-nologin='true'
+          data-embed='true'>
         </div>
+      </div>
     </div>
-</div>
-</section>
+  </section>
 </main>
+
 <?php get_footer(); ?>


### PR DESCRIPTION
Also adds .editorconfig file to help with consistency.

# What does this pull request do?

Removes hard-coded text from `page-newsletter.php` and `page-get-involved.php` in favor of data from WordPress. Requires these templates to have a `hero_image` and `inner_section_title` ACF populated.

# How should the reviewer test this pull request?

Enable ACF "Inner Content" field group on Top Level Pages, then populate these fields for the pages/templates above.

(Maybe install [EditorConfig](http://editorconfig.org/) in your editor?)

# Include the Basecamp todo for this PR, if there is one.

462586208
