### PR TITLE
Stop using custom fields in the press release query

### DIFF
--- a/wp-content/themes/pawar2018/archive-press-releases.php
+++ b/wp-content/themes/pawar2018/archive-press-releases.php
@@ -15,8 +15,6 @@
         $args = array(
           'post_type' => 'press-releases',
           'posts_per_page' => 5,
-          'meta_key' => 'date',
-          'orderby' => 'meta_value_num',
           'paged' => $paged,
           'order' => 'DESC') ?>
       <?php $loop = new WP_Query( $args ); ?>


### PR DESCRIPTION
# What does this pull request do?

Stops using the 'date' custom field for Press Releases

# How should the reviewer test this pull request?

View the press releases. Do they show up in the expected order? 

# Include the Basecamp todo for this PR, if there is one.


# Include any screenshots that will help explain this PR.

# Any another context you want to provide?

We changed Press Releases to use the built-in WordPress date field elsewhere. We need to do so here as well. 
