### PR TITLE
Privacy policy styling and footer link

### DIFF
--- a/wp-content/themes/pawar2018/footer.php
+++ b/wp-content/themes/pawar2018/footer.php
@@ -27,6 +27,7 @@
 		        <a class="footer-nav__link" href="/events">Events</a>
 		        <a class="footer-nav__link" href="/get-involved">Get Involved</a>
 		        <a class="footer-nav__link" href="/press-releases">Press Releases</a>
+                <a class="footer-nav__link" href="/privacy-policy">Privacy Policy</a>
 		        <a class="footer-nav__link" href="https://act.myngp.com/Forms/9188561423484586496" target="_blank">Donate</a>
 			</nav>
 		</div>

--- a/wp-content/themes/pawar2018/sass/pages/_privacy.scss
+++ b/wp-content/themes/pawar2018/sass/pages/_privacy.scss
@@ -1,0 +1,6 @@
+.privacy-policy {
+    ul {
+        margin-left: 1.25rem;
+        margin-bottom: 1.5rem;
+    }
+}

--- a/wp-content/themes/pawar2018/sass/style.scss
+++ b/wp-content/themes/pawar2018/sass/style.scss
@@ -130,3 +130,4 @@ CSS file.
 //In wordpress this might not be needed
 @import "pages/issues";
 @import "pages/ngp";
+@import "pages/privacy";


### PR DESCRIPTION
# What does this pull request do?

This adds styling and a footer link for the privacy policy page at /privacy-policy

This file contains the content for that page (the page exists in the DB, it just has no content). I've also added this content into staging:

[privacy.txt](https://github.com/pawar-2018/pawar2018/files/985341/privacy.txt)

# How should the reviewer test this pull request?

Click the footer link and view the privacy policy page. 

# Include the Trello card for this PR, if there is one.

https://trello.com/c/a9S03mCn

# Include any screenshots that will help explain this PR.

<img width="673" alt="screen shot 2017-05-08 at 8 58 36 pm" src="https://cloud.githubusercontent.com/assets/899/25832611/4efb3884-3431-11e7-822b-f2affd0143ca.png">
<img width="667" alt="screen shot 2017-05-08 at 8 58 55 pm" src="https://cloud.githubusercontent.com/assets/899/25832613/532f0336-3431-11e7-98b6-397ee188d6ca.png">
<img width="286" alt="screen shot 2017-05-08 at 8 59 21 pm" src="https://cloud.githubusercontent.com/assets/899/25832618/56ef4bb6-3431-11e7-83e2-103f5436ba81.png">


# Any another context you want to provide?

If there's an additional step I should take to get the content into prod, please let me know. 
