### PR TITLE
Update to prefixing for defaults instead of 'last 2 versions' cause l…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,6 @@ gulp.task('styles', function() {
     .pipe($.sass({outputStyle: 'compressed'
     }).on('error', $.sass.logError))
     .pipe($.postcss([autoprefixer({
-      browsers: ['last 2 version'],
       cascade: false
     })]))
     .pipe($.cssnano())


### PR DESCRIPTION
…ess coverage

# What does this pull request do?
Autoprefixer 
# How should the reviewer test this pull request?
Make sure it's compiling for any browser that has stats just above 1%
# Include the Trello card for this PR, if there is one.
https://trello.com/c/DvA900JZ/34-figure-out-why-the-autoprefixer-isnt-working-general-build-process-optimization
# Include any screenshots that will help explain this PR.
![autoprefixer](https://cloud.githubusercontent.com/assets/4666838/25928092/df0c7c78-35bf-11e7-8f0e-6f45cf9e70fd.JPG)
# Any another context you want to provide?
na