### PR TITLE
Increase PHP's upload_max_filesize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 !wp-content/
 !gulpfile.js
 !.babelrc
+!Dockerfile
 
 # Ignore everything in the "wp-content" directory, except the "plugins"
 # and "themes" directories.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM wordpress:latest
+
+RUN touch /usr/local/etc/php/conf.d/uploads.ini \
+    && echo "upload_max_filesize = 10M;" >> /usr/local/etc/php/conf.d/uploads.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
        MYSQL_PASSWORD: wordpress
 
    wordpress:
+     build: .
      depends_on:
        - db
-     image: wordpress:latest
      ports:
        - "8000:80"
      restart: always


### PR DESCRIPTION
# What does this pull request do?
Adds a new Dockerfile that extends the wordpress:latest image to increase PHP's upload_max_filesize (making an import of the staging site XML possible locally) 

# How should the reviewer test this pull request?
- `docker-compose down`
- `docker-compose up -d`

Docker should detect the new image and build it.

# Include the Trello card for this PR, if there is one.
https://trello.com/c/VAlmJVMg

# Additional context
It may also be desirable to up the memory limit setting to handle the large file, but I thought I'd keep the pull request small and isolated at first. 