### PR TITLE
Dynamic menus

### DIFF
--- a/wp-content/themes/pawar2018/footer.php
+++ b/wp-content/themes/pawar2018/footer.php
@@ -22,13 +22,14 @@
 		        <a class="footer-nav__link show-for-large" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="Back to the Home Page">
 		          <img class="footer-nav__logo" src="<?php echo get_bloginfo('template_url') ?>/assets/logo.svg"  alt="Ameya Pawar 2018 Logo">
 		        </a>
-		        <a class="footer-nav__link" href="/meet-ameya">About</a>
-		        <a class="footer-nav__link" href="/issues">Issues</a>
-		        <a class="footer-nav__link" href="/events">Events</a>
-		        <a class="footer-nav__link" href="/get-involved">Get Involved</a>
-		        <a class="footer-nav__link" href="/press-releases">Press Releases</a>
-		        <a class="footer-nav__link" href="/privacy-policy">Privacy Policy</a>
-		        <a class="footer-nav__link" href="/donate">Donate</a>
+		        <?php 
+					$footer_menu_items = get_items_by_location('footer-menu');
+					foreach ($footer_menu_items as $item) {
+						$classes = implode(' ', $item->classes);
+						$classes .= ' footer-nav__link';
+						echo "<a class=\"{$classes}\" href=\"{$item->url}\">{$item->title}</a>";
+					}
+				?>
 			</nav>
 		</div>
 		<div class="small-11 medium-5 large-4 columns">

--- a/wp-content/themes/pawar2018/functions.php
+++ b/wp-content/themes/pawar2018/functions.php
@@ -44,7 +44,8 @@ function _pawar2018_setup() {
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
-		'menu-1' => esc_html__( 'Primary', 'Pawar2018' ),
+	    'header-menu' => __( 'Header Menu' ),
+	    'footer-menu' => __( 'Footer Menu' )
 	) );
 
 	/*
@@ -138,6 +139,11 @@ require get_template_directory() . '/inc/customizer.php';
  * Load Jetpack compatibility file.
  */
 require get_template_directory() . '/inc/jetpack.php';
+
+/**
+ * Header and footer menu customizations
+ */
+require get_template_directory() . '/inc/menus.php';
 
 /*
  $new_role = add_role('event_team_lead',

--- a/wp-content/themes/pawar2018/header.php
+++ b/wp-content/themes/pawar2018/header.php
@@ -6,24 +6,25 @@
         <?php get_template_part('template-parts/header', 'logo'); ?>
 
 		<div class="header-burger__icon">
-      <span class="line line-top"></span>
-      <span class="line line-middle"></span>
-      <span class="line line-bottom"></span>
+      		<span class="line line-top"></span>
+      		<span class="line line-middle"></span>
+      		<span class="line line-bottom"></span>
 		</div>
 
 		<nav class="header-nav">
-            <a class="header-nav__link <?php if(is_page('meet-ameya')) {?> active <?php } ?>" href="/meet-ameya" aria-label="Link to Meet Ameya Page">
-                Meet Ameya
-            </a>
-            <a class="header-nav__link  <?php if(is_page('issues')) {?> active <?php } ?>" href="/issues" aria-label="Link to Issues Page">
-                Issues
-            </a>
-			<a class="header-nav__link <?php if(is_page('events')) {?> active <?php } ?>" href="/events" aria-label="Link to Events Page">
-              Events
-            </a>
-			<a class="header-nav__link <?php if(is_page('get-involved')) {?> active <?php } ?>" href="/get-involved" aria-label="Link to Get Involved Page">
-                Get Involved
-            </a>
+            <?php 
+				$header_menu_items = get_items_by_location('header-menu');
+				foreach ($header_menu_items as $item) {
+					$classes = implode(' ', $item->classes);
+					$classes .= ' header-nav__link';
+					if(is_page($item->title) || is_post_type_archive( $item->object )) {
+						$classes .= ' active';
+					}
+
+					echo "<a class=\"{$classes}\" href=\"{$item->url}\" aria-label=\"Link to {$item->title} Page\">{$item->title}</a>";
+				}
+			?>
+
 			<div class="header-social">
 				<a class="header-social__link" href="https://www.facebook.com/AmeyaPawarIL/" target="_blank" aria-label="Link to Facebook AmeyaPawarIL">
 					<img src="<?php echo get_bloginfo('template_url') ?>/assets/facebook.svg" alt="Facebook Icon">
@@ -38,6 +39,7 @@
 					<img src="<?php echo get_bloginfo('template_url') ?>/assets/youtube.svg" alt="Youtube Icon">
 				</a>
 			</div>
+
 			<a class="header-social__button button" href="/donate">
                 Donate
             </a>

--- a/wp-content/themes/pawar2018/inc/menus.php
+++ b/wp-content/themes/pawar2018/inc/menus.php
@@ -1,0 +1,8 @@
+<?php
+
+function get_items_by_location( $theme_location ) {
+	$locations = get_nav_menu_locations();
+	$menu_id = $locations[ $theme_location ] ;
+	$menu = wp_get_nav_menu_object($menu_id);
+	return wp_get_nav_menu_items( $menu->term_id, array( 'order' => 'DESC' ) );
+}


### PR DESCRIPTION
# What does this pull request do?
Uses WordPress menus instead of hardcoded links in the template. This is a prerequisite for I18N.

# How should the reviewer test this pull request?
- Go to Appearance > Menus
- Open the Screen Options drawer at the top and select Events and Press Releases (see below for screenshot)

## Header
- Create a menu named "Header"
- Add the "Meet Ameya", "Issues", and "Get Involved" pages to the menu in that order (drag and drop to reorder after adding them)
- Add the events archive by selecting "All Events" under its "View All" tab
- Open the events archive accordion and change the navigation label to "Events"
- Select "Header Menu" for the display location
- Click "Save Menu"

## Footer
- Create a menu named "Header"
- Add the "Meet Ameya", "Issues", "Get Involved", "Privacy Policy", and "Donate" page to the menu in that order
- Open the "Meet Ameya" accordion and change the navigation label to "About"
- Add the events archive by selecting "All Events" under its "View All" tab
- Move the events archive above the "Get Involved" page
- Open the events archive accordion and change the navigation label to "Events"
- Add the press release archive by selecting "All Press Releases" under its "View All" tab
- Move the press release archive above the "Privacy Policy" page
- Open the press release archive accordion and change the navigation label to "Press Releases"
- Select "Footer Menu" for the display location
- Click "Save Menu"

# Include the Trello card for this PR, if there is one.
https://trello.com/c/EwV5V6bf

# Include any screenshots that will help explain this PR.
To include links to the Events and Press Releases archive pages, first make sure they're selected in the Screen Options drawer at the top of Appearance > Menus.
![screen shot 2017-05-21 at 10 11 11 pm](https://cloud.githubusercontent.com/assets/772939/26291287/ec3ec1a6-3e72-11e7-9072-33bf96da3706.png)

After creating a menu, open up the accordion for the taxonomy type on the left, click the "View All" tab, select the "All" option at the top, and click "Add to Menu".
![screen shot 2017-05-21 at 10 11 30 pm](https://cloud.githubusercontent.com/assets/772939/26291329/1e617db8-3e73-11e7-9eaf-69a3d8fa0a13.png)

Edit the label used in the menu for a page or archive by opening the accordion item on the right and changing the "Navigation Label".
![screen shot 2017-05-21 at 10 11 44 pm](https://cloud.githubusercontent.com/assets/772939/26291362/563d5b94-3e73-11e7-9fc4-7b4a53130efa.png)

# Any another context you want to provide?
I tried using `wp_nav_menu()` [link](https://developer.wordpress.org/reference/functions/wp_nav_menu/), but ran into two problems. First, inserting the social buttons into the same `<nav>` element as the links required putting all their markup in a function and adding them to menu as part of a filter. Second, un-nesting the links from the WordPress default `<li>` wrapper required the use of a custom walker function. Both could have been avoided with significant updates to the CSS, but using `wp_get_nav_menu_items()` [link](https://developer.wordpress.org/reference/functions/wp_get_nav_menu_items/) instead seemed like it achieved the goal without major style changes or creating code that would be difficult to understand and maintain.