### PR TITLE
fixing volume path for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,6 @@ services:
        WORDPRESS_DB_HOST: db:3306
        WORDPRESS_DB_PASSWORD: wordpress
      volumes:
-       - /wp-content:/var/www/html/wp-content
+       - ./wp-content:/var/www/html/wp-content
 volumes:
     db_data:


### PR DESCRIPTION
# What does this pull request do?

Changes the wp-content volume path to refer to the local `wp-content` directory, rather than expecting a global one. 
# How should the reviewer test this pull request?

run `docker-compose up` and verify it comes up
# Include the Trello card for this PR, if there is one.
N/A
# Include any screenshots that will help explain this PR.
N/A

# Any another context you want to provide?