### PR TITLE
Pr date fixes

### DIFF
--- a/wp-content/themes/pawar2018/archive-press-releases.php
+++ b/wp-content/themes/pawar2018/archive-press-releases.php
@@ -25,7 +25,7 @@
             </a>
           </h1>
           <h6 class="press-release__date">
-            <?php the_date('F j, Y'); ?>
+            <?php the_time( get_option( 'date_format' ) ); ?>
           </h6>
           <p><?php the_content( 'Read more...') ?></p>
           <?php

--- a/wp-content/themes/pawar2018/single-press-releases.php
+++ b/wp-content/themes/pawar2018/single-press-releases.php
@@ -11,7 +11,7 @@
       <div class="row align-center">
         <div class="small-12 medium-12 columns">
           <h1 class="section-title"><?php echo the_title(); ?></h1>
-          <h6 class="press-release__date"><?php the_date('F jS, Y'); ?></h6>
+          <h6 class="press-release__date"><?php the_time( get_option( 'date_format' ) ); ?></h6>
           <?php the_content(); ?>
         </div>
       </div>


### PR DESCRIPTION
# What does this pull request do?
Shows the date for each press release on the archive page, even if they were posted on the same day. Also uses the date format defined in General Settings in the admin menu, which is currently set to the requested "F j, Y" (e.g., "April 19, 2017").

# How should the reviewer test this pull request?
- Click the Press Releases link in the footer
- Scroll down to the two releases posted on April 19, 2017
- Click on one of them and make sure the date does not have an ordinal indicator (i.e., "19" instead of "19th")

# Include the Trello card for this PR, if there is one.
https://trello.com/c/tftHqxVp
