### PR TITLE
Add name to Eventbrite template

### DIFF
--- a/wp-content/themes/pawar2018/archive-events.php
+++ b/wp-content/themes/pawar2018/archive-events.php
@@ -1,4 +1,8 @@
-<?php get_header(); ?>
+<?php 
+/*
+Template name: Eventbrite Events
+ */
+get_header(); ?>
 
 <main>
   <section class="hero inner-page"
@@ -17,6 +21,7 @@
       <div class="small-12 medium-5 large-6 small-order-1 medium-order-2 columns">
 
         <?php
+        error_log('archive');
         // Set up and call our Eventbrite query.
         $events = new Eventbrite_Query(apply_filters('eventbrite_query_args', array()));
 


### PR DESCRIPTION
# What does this pull request do?
Adds a name to the Eventbrite template so it can be chosen as a template. This will make it possible to fix the issue with navigating past page one in the events list.

# How should the reviewer test this pull request?
- Observe that http://localhost:8000/events/page/2/ returns a 404
- Create a page named Events that uses the "Eventbrite Events" template
- Visit http://localhost:8000/events/page/2/ again and use the pagination at the bottom

# Include the Trello card for this PR, if there is one.
https://trello.com/c/dPXqOfr6

# Any another context you want to provide?
👩🏼 🐲 🐲 🐲  👨🏻 🐺 