### PR TITLE
Migrate I18N changes to Eventbrite plugin template

### DIFF
--- a/wp-content/mu-plugins/eventbrite-api/tmpl/eventbrite-index.php
+++ b/wp-content/mu-plugins/eventbrite-api/tmpl/eventbrite-index.php
@@ -4,21 +4,23 @@
   <section class="hero inner-page"
            style="background-image: url('<?php echo get_bloginfo('template_url') ?>/assets/events-hero.jpg'); background-size: cover;">
     <div class="row align-center align-middle">
-      <h1 class="page-title">Events</h1>
+      <h1 class="page-title"><?php if(function_exists('pll_e')) pll_e('Events'); ?></h1>
     </div>
   </section>
   <section class="body">
     <div class="row align-center">
       <div class="small-11 medium-5 large-4 small-order-2 medium-order-1 columns">
-        <h1 class="section-title">Let's Talk</h1>
-        <p>Looking to host an event?</p>
-        <a href='/get-involved' class="button">Contact Us</a>
+        <h1 class="section-title"><?php if(function_exists('pll_e')) pll_e("Let's Talk"); ?></h1>
+        <p><?php if(function_exists('pll_e')) pll_e('Looking to host an event?'); ?></p>
+        <a href="<?php if(function_exists('pll_e')) pll_e('/get-involved'); ?>" class="button"><?php if(function_exists('pll_e')) pll_e('Contact Us'); ?></a>
       </div>
       <div class="small-12 medium-5 large-6 small-order-1 medium-order-2 columns">
 
         <?php
         // Set up and call our Eventbrite query.
-        $events = new Eventbrite_Query(apply_filters('eventbrite_query_args', array()));
+        $events = new Eventbrite_Query(apply_filters('eventbrite_query_args', array(
+          'organizer_id' => 13080157631
+        )));
 
         if ($events->have_posts()) :
           while ($events->have_posts()) :
@@ -28,16 +30,17 @@
               <div class="small-3 medium-10 large-2 columns">
                 <div class="event-date_circle">
                   <?php $date = date_create(eventbrite_event_start()->local); ?>
-                  <?php echo date_format($date, 'd'); ?><br><?php echo date_format($date, 'F');; ?>
+                  <?php echo date_format($date, 'd'); ?><br><?php echo date_i18n( 'M', strtotime(eventbrite_event_start()->local) ); ?>
                 </div>
               </div>
               <div id="event-<?php the_ID(); ?>" class="small-11 large-7 large-offset-1 columns event-copy">
                 <?php get_field('link') ?>
-                <a href="<?php the_field('link'); ?>">
+                <a href="<?= eventbrite_event_eb_url(); ?>">
 
                   <p class="event-date">
                     <?php
-                    echo date_format($date, 'l, F d \a\t h:i a');
+                      $formatString = function_exists('pll__') ? pll__('l, F d \a\t g:i a') : 'l, F d \a\t g:i a';
+                      echo date_i18n( $formatString, strtotime(eventbrite_event_start()->local) );
                     ?>
                   </p>
 
@@ -45,9 +48,9 @@
                     <?php the_title(sprintf('<h5 class="event-title">', esc_url(get_permalink())), '</h5>'); ?>
                   </h5>
 
-                  <p class="event-locale"><?= eventbrite_event_venue()->name; ?></p>
-                  <p><?= eventbrite_event_venue()->address->localized_multi_line_address_display[0]; ?></p>
-                  <p><?= eventbrite_event_venue()->address->localized_multi_line_address_display[1]; ?></p>
+                  <p class="event-locale"><?= eventbrite_event_venue()->name; ?><br/>
+                  <?= eventbrite_event_venue()->address->localized_multi_line_address_display[0]; ?><br/>
+                  <?= eventbrite_event_venue()->address->localized_multi_line_address_display[1]; ?></p>
 
                   <footer class="entry-footer">
                     <?php eventbrite_edit_post_link(__('Edit', 'eventbrite_api'), '<span class="edit-link">', '</span>'); ?>

--- a/wp-content/themes/pawar2018/front-page.php
+++ b/wp-content/themes/pawar2018/front-page.php
@@ -104,7 +104,7 @@ get_header(); ?>
                     <a href="<?= eventbrite_event_eb_url(); ?>">
                       <p class="event-date">
                         <?php
-                          $formatString = function_exists('pll_e') ? pll__('l, F d \a\t h:i a') : 'l, F d \a\t h:i a';
+                          $formatString = function_exists('pll__') ? pll__('l, F d \a\t g:i a') : 'l, F d \a\t g:i a';
                           echo date_i18n( $formatString, strtotime(eventbrite_event_start()->local) );
                         ?>
                       </p>

--- a/wp-content/themes/pawar2018/functions.php
+++ b/wp-content/themes/pawar2018/functions.php
@@ -76,7 +76,7 @@ function _pawar2018_setup() {
 		pll_register_string( 'Events CTA text', 'Looking to host an event?', 'Events');
 		pll_register_string( 'Events CTA button', 'Contact Us', 'Events');
 		pll_register_string( 'Events CTA URL', '/get-involved', 'Events');
-		pll_register_string( 'Eventbrite date format', 'l, F d \a\t h:i a', 'Events');
+		pll_register_string( 'Eventbrite date format', 'l, F d \a\t g:i a', 'Events');
 		pll_register_string( 'Signup title', 'Newsletter', 'Footer');
 		pll_register_string( 'Signup text', 'Stay in the loop.', 'Footer');
 		pll_register_string( 'Signup button', 'Subscribe', 'Footer');


### PR DESCRIPTION
# What does this pull request do?
Recreates the I18N changes to the Eventbrite plugin template (and includes a couple recent changes to the page from the "rush job" PR, too).

To make Eventbrite paging work, the custom post type of events needs to be deleted. Once I deleted that, the /events path started resolving to the new page and pagination started working properly. 

BUT, I had coincidentally chosen the exact same name as the default template in the plugin. When I thought I was testing locally against the template in /wp-content I was actually testing against the default template. The plugin definitely favors their default template, so I'm taking the path of least resistance here and migrating the updates we've made.

# How should the reviewer test this pull request?
- Create an /events page with the "Eventbrite Events" template
- Delete the Events Custom Post Type in CPT UI > Add/Edit Post Types > Edit Post Type
- Visit /events

# Include the Trello card for this PR, if there is one.
https://trello.com/c/dPXqOfr6

# Any another context you want to provide?
📄 📄 😕